### PR TITLE
SEO, security and accessibility improvements

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -6,7 +6,9 @@ const contentSecurityPolicy = [
   "object-src 'none'",
   "frame-ancestors 'none'",
   "form-action 'self'",
-  "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+  process.env.NODE_ENV === "development"
+    ? "script-src 'self' 'unsafe-inline' 'unsafe-eval'"
+    : "script-src 'self' 'unsafe-inline'",
   "style-src 'self' 'unsafe-inline'",
   "img-src 'self' data: blob: https://images.prismic.io https://*.cdn.prismic.io https://prismic-io.s3.amazonaws.com https://i.ytimg.com https://*.vercel.app https://*.vercel-storage.com",
   "font-src 'self' data:",

--- a/src/app/[locale]/error.tsx
+++ b/src/app/[locale]/error.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect } from "react";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center gap-6 px-6 text-center">
+      <h1 className="font-bangers text-4xl tracking-wide text-[var(--hotc-ember)]">
+        Something went wrong
+      </h1>
+      <p className="max-w-md text-[var(--hotc-ink-2)]">
+        {error.message || "An unexpected error occurred. Please try again."}
+      </p>
+      <button
+        type="button"
+        onClick={reset}
+        className="hotc-btn hotc-btn--ember"
+      >
+        Try again
+      </button>
+    </div>
+  );
+}

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,15 @@
+import { MetadataRoute } from "next";
+import { metadataBase } from "@/lib/seo";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: ["/api/", "/slice-simulator"],
+      },
+    ],
+    sitemap: new URL("/sitemap.xml", metadataBase).toString(),
+  };
+}

--- a/src/app/root-document.tsx
+++ b/src/app/root-document.tsx
@@ -4,15 +4,15 @@ const bangers = Bangers({
   weight: "400",
   subsets: ["latin"],
   variable: "--font-bangers",
-  display: "optional",
-  preload: false,
+  display: "swap",
+  preload: true,
 });
 
 const bowlbyOne = Bowlby_One({
   weight: "400",
   subsets: ["latin"],
   variable: "--font-bowlby-one",
-  display: "optional",
+  display: "swap",
   preload: false,
 });
 
@@ -20,7 +20,7 @@ const permanentMarker = Permanent_Marker({
   weight: "400",
   subsets: ["latin"],
   variable: "--font-permanent-marker",
-  display: "optional",
+  display: "swap",
   preload: false,
 });
 

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,60 @@
+import { MetadataRoute } from "next";
+import { createClient } from "@/prismicio";
+import { metadataBase } from "@/lib/seo";
+import { SUPPORTED_LOCALES, toPrismicLang, type AppLocale } from "@/lib/locale";
+import { filterVisibleDocuments } from "@/lib/content-visibility";
+
+function url(path: string): string {
+  return new URL(path, metadataBase).toString();
+}
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const client = createClient();
+  const entries: MetadataRoute.Sitemap = [];
+
+  // Static routes per locale
+  const staticPaths = ["", "/episodes", "/characters", "/lore", "/store"];
+  for (const locale of SUPPORTED_LOCALES) {
+    for (const path of staticPaths) {
+      entries.push({ url: url(`/${locale}${path}`), alternates: { languages: Object.fromEntries(SUPPORTED_LOCALES.map((l) => [l, url(`/${l}${path}`)])) } });
+    }
+  }
+
+  // Dynamic routes — fetch all locales in parallel
+  const fetches = SUPPORTED_LOCALES.map(async (locale: AppLocale) => {
+    const lang = toPrismicLang(locale);
+
+    const [episodes, characters, loreEntries, pages] = await Promise.all([
+      client.getAllByType("episode", { lang }).catch(() => []),
+      client.getAllByType("character", { lang }).catch(() => []),
+      client.getAllByType("lore_entry", { lang }).catch(() => []),
+      client.getAllByType("page", { lang }).catch(() => []),
+    ]);
+
+    const results: MetadataRoute.Sitemap = [];
+
+    for (const ep of filterVisibleDocuments(episodes)) {
+      results.push({ url: url(`/${locale}/episodes/${ep.uid}`) });
+    }
+    for (const char of filterVisibleDocuments(characters)) {
+      results.push({ url: url(`/${locale}/characters/${char.uid}`) });
+    }
+    for (const entry of filterVisibleDocuments(loreEntries)) {
+      results.push({ url: url(`/${locale}/lore/${entry.uid}`) });
+    }
+    for (const page of filterVisibleDocuments(pages)) {
+      if (page.uid && page.uid !== "home") {
+        results.push({ url: url(`/${locale}/${page.uid}`) });
+      }
+    }
+
+    return results;
+  });
+
+  const dynamicEntries = await Promise.all(fetches);
+  for (const batch of dynamicEntries) {
+    entries.push(...batch);
+  }
+
+  return entries;
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,7 +2,7 @@
 
 import { Content, asLink, asText } from "@prismicio/client";
 import Link from "next/link";
-import { useState, useTransition } from "react";
+import { useState, useTransition, useEffect, useRef } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import BrandLogo from "@/components/BrandLogo";
 import SocialIcon, { getSocialKey } from "@/components/SocialIcon";
@@ -23,7 +23,8 @@ type Props = {
 };
 
 function persistLocalePreference(locale: AppLocale) {
-  document.cookie = `${LOCALE_COOKIE_NAME}=${locale}; path=/; max-age=31536000; samesite=lax`;
+  const secure = location.protocol === "https:" ? "; Secure" : "";
+  document.cookie = `${LOCALE_COOKIE_NAME}=${locale}; path=/; max-age=31536000; samesite=lax${secure}`;
 }
 
 export default function Header({ settings, navigation, currentLocale }: Props) {
@@ -33,6 +34,42 @@ export default function Header({ settings, navigation, currentLocale }: Props) {
   const [isPending, startTransition] = useTransition();
   const pathname = usePathname();
   const router = useRouter();
+  const drawerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const drawer = drawerRef.current;
+    if (!drawer) return;
+
+    const focusable = drawer.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    );
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+
+    first?.focus();
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key !== "Tab") return;
+      if (focusable.length === 0) { e.preventDefault(); return; }
+
+      if (e.shiftKey) {
+        if (document.activeElement === first) {
+          e.preventDefault();
+          last?.focus();
+        }
+      } else {
+        if (document.activeElement === last) {
+          e.preventDefault();
+          first?.focus();
+        }
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [open]);
   const nav = navigation?.data.primary_links ?? [];
   const navItems = nav.map((n) => ({
     href: resolveAppLinkHref(n.link, currentLocale) ?? asLink(n.link) ?? "",
@@ -214,6 +251,7 @@ export default function Header({ settings, navigation, currentLocale }: Props) {
 
       <div
         id="hotc-mobile-menu"
+        ref={drawerRef}
         className={`hotc-header__drawer${open ? " is-open" : ""}`}
         aria-hidden={!open}
       >


### PR DESCRIPTION
## Summary

- **Fonts**: changed `display: 'optional'` → `display: 'swap'` on all three Google Fonts (Bangers, Bowlby One, Permanent Marker); enabled `preload: true` on Bangers so the primary display font is always loaded for users
- **Error boundary**: added `src/app/[locale]/error.tsx` — a branded error page with a \"Try again\" button that catches runtime failures in any locale route (Prismic fetch errors, slice crashes, etc.)
- **Sitemap**: added `src/app/sitemap.ts` — dynamically fetches all published episodes, characters, lore entries and pages from Prismic across both locales (en/es) and generates a valid XML sitemap with hreflang alternates
- **robots.txt**: added `src/app/robots.ts` — allows all crawlers, blocks `/api/` and `/slice-simulator`, and points to the sitemap URL
- **CSP hardening**: `'unsafe-eval'` removed from `script-src` in production builds (Turbopack only needs it in development); no change in dev behaviour
- **Header security**: locale cookie now includes the `Secure` flag when running over HTTPS (production on Vercel); keyboard focus is now trapped inside the mobile drawer when open, so Tab/Shift+Tab can't escape to background content

## Test plan

- [ ] `npm run build` completes without errors
- [ ] `/robots.txt` returns correct disallow rules and sitemap URL
- [ ] `/sitemap.xml` returns valid XML with URLs for all published content in both locales
- [ ] Open mobile menu, Tab through all items — focus should cycle inside the drawer
- [ ] On production (HTTPS), inspect `hotc-locale` cookie — should have `Secure` flag
- [ ] Trigger a Prismic error (disconnect / bad UID) — should render the branded error page instead of Next.js default

🤖 Generated with [Claude Code](https://claude.com/claude-code)